### PR TITLE
add posit cloud links and demo placeholder 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ Disaster Dash is an interactive dashboard to provide data to assist with Global 
 
 This dashboard is a group project for the Master of Data Science program at the University of British Columbia, DSCI 532: Data Visualization, 2025-26 Cohort.
 
+## Deployed App
+
+| Build | URL |
+|-------|-----|
+| Stable (main) | [disasterdash-stable](https://clr-saunders-dsci-532-2026-18-disasterdash-stable.share.connect.posit.cloud)|
+| Preview (dev) | [disasterdash-preview](https://clr-saunders-dsci-532-2026-18-disasterdash-preview.share.connect.posit.cloud)|
+
+
+## Demo
+
+![Demo](img/demo.gif)
+
 ## Running the Dashboard Locally
 
 1. Clone this repository
@@ -31,7 +43,18 @@ shiny run src/app.py
 
 5. Open your browser to the URL shown in the terminal.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to this project.
+
+## Contributors
+
+| Name | GitHub |
+|------|--------|
+| Ojasv Issar | [@Ojasv-Issar](https://github.com/Ojasv-Issar) |
+| Joel Nicholas Peterson | [@j031nich0145](https://github.com/j031nich0145) |
+| Claire Saunders | [@clr-saunders](https://github.com/clr-saunders) |
+
 ## License
 
 Software licensed under the MIT License. Content licensed under CC BY 4.0. See [LICENSE.md](LICENSE.md) for details.
-

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## About
 
-Disaster Dash is an interactive dashboard to provide data to assist with Global Disaster Aid Policy development. Users can see the frequency of disasters on a World Map, and filter by disaster type, dates, and countries. By using our dashboard, a policy developer can immediately see the most frequent disasters around the world, and compare the economic loss and global aid response provided through simple, clear visualizations.
+Global aid policy workers face a critical challenge: understanding where disaster aid responses are insufficient compared to actual economic losses. Without a clear understanding of the aid gaps, policymakers may struggle to develop effective responses to global disasters.
+
+Disaster Dash is an interactive dashboard that makes these gaps visible. Users can explore global disaster frequency on a World Map, filter by disaster type, dates, and countries, and directly compare economic losses against aid responses through clear visualizations.
 
 This dashboard is a group project for the Master of Data Science program at the University of British Columbia, DSCI 532: Data Visualization, 2025-26 Cohort.
 


### PR DESCRIPTION
Closes #21 

Read Me Updates: 
- Added the two Posit Connect Cloud url's, stable and preview. Preview is linked to dev and stable is linked to main. 
- About section edited to as required to "make clear the dashboard motivation, what the dashboard solves" 
- Added a stand in section for the gif to be added later in this milestone (References #24) 
- Added our names and github id's as requested by TA in lab today (Feb 23).

Repo Description Update: 
- Please note I updated our repo description to include the stable url, and keywords as required. 