### PR TITLE
Kpi cards

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -136,7 +136,6 @@ app_ui = ui.page_fillable(
                 ui.value_box(
                     "Aid Coverage",
                     ui.output_text("kpi_ratio")
-
                 ),
                 ui.value_box(
                     "Aid Gap",
@@ -206,6 +205,12 @@ def server(input, output, session):
         ui.update_select(
             id="summary_stat", 
             selected="mean",
+            session=session
+        )
+        ui.update_date_range(
+            id="date_range",
+            start="2018-01-01",
+            end="2024-12-31",
             session=session
         )
     # Filtered Dataframe 


### PR DESCRIPTION
## Closes #30 

Builds on #41
Resulted in updated specs in #22

## Summary 

* Reads in `global_disaster_response_2018_2024.csv` with parsed dates.
* Adds `filtered_df()` reactive to filter by:

  * Selected countries
  * Selected disaster types
  * Selected date range
* Adds KPI value boxes:

  * **Aid Coverage** — % of total loss covered by aid
  * **Aid Gap** — $ amount of loss not covered by aid
Both KPIs use total sums from `filtered_df()` and are independent of `summary_stat`.

### Spec Update

Updated #22 to introduce a separate `aggregated_df()` reactive.
This keeps `filtered_df()` as row-level data for accurate KPI calculations, while allowing future aggregation for bar charts without affecting KPI logic.

Thank you!! 