### PR TITLE
document optional complexity enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added active filter strip banner displaying current filter state at a glance.
 - Added "None" deselect buttons alongside existing "All" buttons for country and disaster type filters.
 - Added empty state placeholders across all chart panels when no data matches the current filters.
+- Implemented optional complexity enhancement: Reset All Filters button using `@reactive.event` and `@reactive.effect` to programmatically restore all inputs to default values.
 
 
 ## Changed:
@@ -50,10 +51,11 @@
 
 - Job Stories 1–4 are fully implemented (global filtering, reactive summaries, bar charts with configurable statistics, and KPI cards).
 - Map and bar chart components are implemented as prototype versions and will be refined in M3.
-- Layout evolved from original M1 sketch to improve information hierarchy and align with dashboard best practices.
+- Layout evolved from the original M1 sketch to a single-page overview design with a dominant choropleth map, two KPI cards (Aid Coverage % and Funding Gap), and horizontally oriented bar charts for improved readability and clearer emphasis on aid gaps.
 - Reactive architecture follows Lecture 3 guidance: a central `filtered_df` reactive calc feeds multiple outputs, with bar chart aggregation applied inline per chart.
 - Strength: Strong reactive separation and modular structure.
 - Limitation: Visual polish and advanced interactivity deferred to M3.
+- Implemented the optional complexity enhancement (Reset All Filters button) to improve workflow and demonstrate event-based reactivity.
 
 At this stage, the dashboard successfully demonstrates full reactivity and deployment workflow, though additional visual refinement and deeper interactivity are planned for M3. Overall, the milestone strengthened our understanding of reactive design patterns and deployment structure.
 

--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -41,6 +41,7 @@ flowchart TD
     D --> Strip
     E[/summary_stat/] --> BarLoss
     E --> BarAid
+    E --> Strip
 
     F --> Map([map_plot: Choropleth])
     F --> KPI([kpi_grid: Aid Coverage & Funding Gap])
@@ -69,3 +70,19 @@ flowchart TD
 ### Map Aggregation (inline)
 - **Depends on:** `filtered_df`, `map_metric`
 - **Transformation:** Groups by `country`, computes disaster count, total casualties, total economic loss, total aid, average severity, average response time, and aid coverage %. The selected `map_metric` controls which variable drives the choropleth colour scale.
+
+
+## Complexity Enhancement
+
+### Reset All Filters Button
+
+To improve usability and demonstrate event-driven reactivity, we implemented a **Reset All Filters** button that restores every global input to its default state.
+
+This feature uses `@reactive.event()` in combination with `@reactive.effect()` to programmatically update all filter widgets when the reset button is clicked.
+
+### Why This Enhances the Dashboard
+
+* Allows users to quickly recover from overly restrictive filter combinations
+* Prevents “empty state” traps during exploratory analysis
+* Improves workflow efficiency when comparing multiple scenarios
+* Demonstrates correct event-based reactive architecture


### PR DESCRIPTION
Hi team,

While reviewing the M2 rubric, I noticed that our Reset All Filters feature qualifies as the optional complexity enhancement (+5), but it must be explicitly documented in both reports/m2_spec.md and CHANGELOG.md to receive credit.

This PR updates:

- reports/m2_spec.md — adds a Complexity Enhancement section describing the reset button and its reactive implementation.

- CHANGELOG.md — explicitly lists the enhancement under Added and references it in the Reflection section.