### PR TITLE
KPI Improvement 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # CHANGELOG 
 
+## [0.3.0] - 2026-03-08
+
+## Added:
+
+- Implemented a new AI-powered tab featuring a querychat interface for natural language filtering.
+- Added a reactive dataframe output displaying the AI-filtered dataset.
+- Added a data download button to export the AI-filtered dataframe.
+- Added GDP-normalized disaster burden metric using **World Bank 2024 GDP data**.
+- Added explanatory subtitles and formulas to KPI cards to clarify metric calculations.
+
+
+
+## Changed:
+
+- Replaced **Aid Coverage %** and **Funding Gap** with:
+   **Total Unfunded Disaster Losses**
+   **Disaster Burden (% of GDP)**.
+
+
+## Fixed:
+
+- Removed decorative KPI icons that were not tied to meaningful analytical comparisons.
+- Updated KPI cards to improve interpretability based on instructor feedback.
+- Refined KPI typography and spacing to improve readability and visual hierarchy.
+
+## Known Issues:
+
+## Reflection:
+
+## Future Upgrades 
+
+
 ## [0.2.0] - 2026-02-28
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -396,30 +396,23 @@ html, body, .bslib-page-fill {{
     border-radius: 14px;
     box-shadow: 0 2px 12px rgba(0,0,0,0.06);
     padding: 18px 16px 14px;
+
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
+
+    justify-content: space-evenly;   /* ⭐ the trick */
+
     text-align: center;
-    position: relative;
-    overflow: hidden;
-    transition: transform 0.15s, box-shadow 0.15s;
+}}
+.kpi-subtitle {{
+    font-size: 0.8rem;
+    color: #475569;
 }}
 .kpi-box:hover {{
     transform: translateY(-2px);
     box-shadow: 0 6px 20px rgba(0,0,0,0.1) !important;
 }}
-.kpi-box::before {{
-    content: '';
-    position: absolute;
-    top: 0; left: 0; right: 0;
-    height: 3px;
-    border-radius: 14px 14px 0 0;
-}}
-.kpi-events::before   {{ background: linear-gradient(90deg, {BLUE}, #60a5fa); }}
-.kpi-cas::before      {{ background: linear-gradient(90deg, {RED}, #f87171); }}
-.kpi-coverage::before {{ background: linear-gradient(90deg, {GREEN}, #34d399); }}
-.kpi-gap::before      {{ background: linear-gradient(90deg, {AMBER}, #fcd34d); }}
 
 .kpi-icon {{
     font-size: 1.4rem;
@@ -428,20 +421,26 @@ html, body, .bslib-page-fill {{
 }}
 .kpi-value {{
     font-family: inherit !important;
-    font-size: 2rem;
-    font-weight: 600;
+    font-size: 2.1rem;
+    font-weight: 700;
     font-variant-numeric: tabular-nums;
-    letter-spacing: 0;
     line-height: 1;
-    margin-bottom: 6px;
+    margin: 6px 0 4px 0;
 }}
 .kpi-title {{
-    font-size: 0.62rem;
+    font-size: 0.7rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 1px;
-    color: {T_SEC};
+    color: #64748b;
 }}
+.kpi-formula {{
+    font-size: 0.68rem;
+    color: #94a3b8;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    letter-spacing: 0.3px;
+}}
+
 /* ── TABS ── */
 .nav-underline {{
     border-bottom: 2px solid {BORDER} !important;
@@ -836,23 +835,28 @@ def server(input, output, session):
                 median_gap_pct = agg["gap_pct_gdp"].median()
                 gap_pct_val = f"{median_gap_pct:.2f}%"
 
-        def kpi_box(cls, value, title, subtitle=None):
+        def kpi_box(cls, value, title, subtitle=None, formula=None):
             return ui.div(
-                ui.div(value, class_="kpi-value"),
                 ui.div(title, class_="kpi-title"),
+                ui.div(value, class_="kpi-value"),
                 ui.div(subtitle, class_="kpi-subtitle") if subtitle else None,
+                ui.div(formula, class_="kpi-formula") if formula else None,
                 class_=f"kpi-box {cls}",
             )
 
         return ui.div(
             kpi_box("kpi-gap",
                      gap_dollar_val, 
-                     "Total Funding Gap", 
-                     "Total Loss - Total Aid"),
+                     "Total Unfunded Disaster Losses", 
+                     "Disaster losses not covered by aid",
+                     "Loss - Aid", 
+                     ),
             kpi_box("kpi-coverage", 
                     gap_pct_val, 
-                    "Median Gap (% of GDP)",
-                    "Typical country shortfall relative to its economy"),
+                    "Disaster Burden (% of GDP)",
+                    "Typical funding gap relative to GDP", 
+                    "Median((Loss − Aid) ÷ GDP)", 
+                    ),
             class_="kpi-grid",
             style="height:100%;",
         )

--- a/src/app.py
+++ b/src/app.py
@@ -38,7 +38,28 @@ ISO3 = {
     "Philippines": "PHL", "South Africa": "ZAF", "Spain": "ESP",
     "Turkey": "TUR",    "United States": "USA",
 }
-
+# ── GDP (Current USD, 2024 World Bank) ─────────────────────────────
+GDP = {
+    "Australia": 1757022451652.83,
+    "Bangladesh": 450119432068.852,
+    "Brazil": 2185821648943.86,
+    "Canada": 2243636826633.76,
+    "Chile": 330267137371.592,
+    "China": 18743803170827.2,
+    "Germany": 4685592577804.69,
+    "Spain": 1725671652742.19,
+    "France": 3160442622465.08,
+    "Greece": 256238371778.118,
+    "Indonesia": 1396300098190.97,
+    "India": 3909891533858.08,
+    "Italy": 2380825077243.59,
+    "Japan": 4027597523550.58,
+    "Mexico": 1856365616165.94,
+    "Nigeria": 252261880141.151,
+    "Philippines": 461617509782.355,
+    "United States": 28750956130731.2,
+    "South Africa": 401144998373.585,
+}
 # ── Helpers ────────────────────────────────────────────────────────────────────
 def fmt_currency(v):
     s = "-" if v < 0 else ""

--- a/src/app.py
+++ b/src/app.py
@@ -427,13 +427,13 @@ html, body, .bslib-page-fill {{
     line-height: 1;
 }}
 .kpi-value {{
-    font-family: 'Syne', sans-serif;
-    font-size: 1.7rem;
-    font-weight: 800;
-    color: {T_PRI};
-    letter-spacing: -0.5px;
+    font-family: inherit !important;
+    font-size: 2rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0;
     line-height: 1;
-    margin-bottom: 5px;
+    margin-bottom: 6px;
 }}
 .kpi-title {{
     font-size: 0.62rem;
@@ -442,7 +442,6 @@ html, body, .bslib-page-fill {{
     letter-spacing: 1px;
     color: {T_SEC};
 }}
-
 /* ── TABS ── */
 .nav-underline {{
     border-bottom: 2px solid {BORDER} !important;
@@ -812,26 +811,48 @@ def server(input, output, session):
     def kpi_grid():
         data = filtered_df()
         if data.empty:
-            cov_val = "—"; gap_val = "—"
+            gap_dollar_val = "-"
+            gap_pct_val = "-"
         else:
-            loss    = data["economic_loss_usd"].sum()
-            aid     = data["aid_amount_usd"].sum()
-            cov     = (aid / loss * 100) if loss > 0 else 0.0
-            gap     = loss - aid
-            cov_val = f"{cov:.1f}%"
-            gap_val = fmt_currency(gap)
+            # Total Funding Gap
+            total_loss    = data["economic_loss_usd"].sum()
+            total_aid     = data["aid_amount_usd"].sum()
+            total_gap     = total_loss - total_aid
+            gap_dollar_val = fmt_currency(total_gap)
+            # GDP Normalized Median Gap (%)
+            agg = (
+                data.groupby("country").agg(
+                    loss=("economic_loss_usd", "sum"),
+                    aid=("aid_amount_usd", "sum")
+                ).reset_index()
+            )
+            agg["gap"] = agg["loss"] - agg["aid"]
+            agg["gdp"] = agg["country"].map(GDP)
 
-        def kpi_box(cls, icon, value, title):
+            if agg.empty:
+                gap_pct_val="-"
+            else:
+                agg["gap_pct_gdp"] = (agg["gap"]/agg["gdp"])*100
+                median_gap_pct = agg["gap_pct_gdp"].median()
+                gap_pct_val = f"{median_gap_pct:.2f}%"
+
+        def kpi_box(cls, value, title, subtitle=None):
             return ui.div(
-                ui.div(icon, class_="kpi-icon"),
                 ui.div(value, class_="kpi-value"),
                 ui.div(title, class_="kpi-title"),
+                ui.div(subtitle, class_="kpi-subtitle") if subtitle else None,
                 class_=f"kpi-box {cls}",
             )
 
         return ui.div(
-            kpi_box("kpi-coverage", "🛡️", cov_val, "Aid Coverage"),
-            kpi_box("kpi-gap",      "⚠️", gap_val, "Funding Gap"),
+            kpi_box("kpi-gap",
+                     gap_dollar_val, 
+                     "Total Funding Gap", 
+                     "Total Loss - Total Aid"),
+            kpi_box("kpi-coverage", 
+                    gap_pct_val, 
+                    "Median Gap (% of GDP)",
+                    "Typical country shortfall relative to its economy"),
             class_="kpi-grid",
             style="height:100%;",
         )


### PR DESCRIPTION
### Improve KPI cards based on Ilya's feedback

This PR updates the KPI cards to incorporates instructor feedback that KPI cards should communicate a clear analytical message and include interpretable metrics with transparent logic.

The main change is a new **GDP-relative disaster burden KPI**. For each selected country, the dashboard calculates the disaster funding gap relative to GDP and reports the **median across countries**, representing the *typical economic burden of disasters*. I used the median so the metric works well when multiple countries are selected and is less dominated by large economies.

Closes #59 
References #58 

**Changes**

* Replaced previous KPIs (**Aid Coverage %** and **Funding Gap**) with:

  * **Total Unfunded Disaster Losses** = Loss − Aid
  * **Disaster Burden (% of GDP)** = Median((Loss − Aid) ÷ GDP)
* Added short explanatory subtitles and formulas for transparency.
* Removed decorative icons that were not tied to a meaningful comparison.
* Improved typography and spacing for readability.
* M3 Changelog started with entry added for this KPI fix and the AI portion Ojasv implemented. 

**GDP metric**

GDP values (2024, current USD) were sourced from the World Bank and mapped to countries in a dictionary. The funding gap is normalized by GDP to show the **economic burden relative to each country's economy**, not just the raw dollar shortfall.

**Why this change**

The previous aid coverage ratio and funding gap showed absolute values but didn’t contextualize losses relative to national economic capacity, and in our dataset the value was extremely uniform and didn't provide a lot of meaningful info.  The GDP-normalized KPI provides a more policy-relevant comparison across countries and responds more meaningfully to different country selections.
