### PR TITLE
Defaults Improvement 

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,5 +1,5 @@
 """
-Disaster Dash (v2) — Improved UI/UX & Functionality
+Disaster Dash (v3) — Improved Storytelling & AI Integration
 Global Disaster Impact & Humanitarian Aid (2018–2024)
 
 Features:
@@ -596,7 +596,7 @@ app_ui = ui.page_fillable(
             ),
 
             ui.div(
-                ui.div("Summary Statistic", class_="sb-label"),
+                ui.div("Bar Chart Statistic", class_="sb-label"),
                 ui.input_select(
                     "summary_stat", label=None,
                     choices=SUMMARY_CHOICES, selected="sum",
@@ -608,7 +608,7 @@ app_ui = ui.page_fillable(
                 ui.div("Map Metric", class_="sb-label"),
                 ui.input_select(
                     "map_metric", label=None,
-                    choices=MAP_METRICS, selected="disasters",
+                    choices=MAP_METRICS, selected="total_loss",
                 ),
                 class_="sb-section",
             ),
@@ -669,7 +669,7 @@ app_ui = ui.page_fillable(
 
             # Footer
             ui.div(
-                ui.span("Disaster Dash v3  ·  "),
+                ui.span("Disaster Dash (v3  ·  "),
                 ui.span("Ojasv Issar, Joel Nicholas Peterson, Claire Saunders  ·  "),
                 ui.a("GitHub", href="https://github.com/UBC-MDS/DSCI-532_2026_18_disasterdash", target="_blank"),
                 ui.span(f"  ·  Data through {LAST_UPDATED}"),
@@ -716,7 +716,7 @@ def server(input, output, session):
         ui.update_selectize("countries",     selected=["Brazil", "Bangladesh", "South Africa"],      session=session)
         ui.update_selectize("disaster_type", selected=DISASTER_TYPES, session=session)
         ui.update_select("summary_stat",     selected="sum",          session=session)
-        ui.update_select("map_metric",       selected="disasters",    session=session)
+        ui.update_select("map_metric",       selected="total_loss",    session=session)
         ui.update_date_range("date_range", start="2018-01-01", end="2024-12-31", session=session)
 
     # ── Active filter strip ───────────────────────────────────────────────────

--- a/src/app.py
+++ b/src/app.py
@@ -568,17 +568,6 @@ app_ui = ui.page_fillable(
                 ),
                 class_="sb-section",
             ),
-
-            ui.div(
-                ui.div("Date Range", class_="sb-label"),
-                ui.input_date_range(
-                    "date_range", label=None,
-                    start="2018-01-01", end="2024-12-31",
-                    min="2018-01-01",   max="2024-12-31",
-                ),
-                class_="sb-section",
-            ),
-
             ui.div(
                 ui.div("Disaster Type", class_="sb-label"),
                 ui.input_selectize(
@@ -594,16 +583,15 @@ app_ui = ui.page_fillable(
                 ),
                 class_="sb-section",
             ),
-
             ui.div(
-                ui.div("Bar Chart Statistic", class_="sb-label"),
-                ui.input_select(
-                    "summary_stat", label=None,
-                    choices=SUMMARY_CHOICES, selected="sum",
+                ui.div("Date Range", class_="sb-label"),
+                ui.input_date_range(
+                    "date_range", label=None,
+                    start="2018-01-01", end="2024-12-31",
+                    min="2018-01-01",   max="2024-12-31",
                 ),
                 class_="sb-section",
             ),
-
             ui.div(
                 ui.div("Map Metric", class_="sb-label"),
                 ui.input_select(
@@ -612,7 +600,14 @@ app_ui = ui.page_fillable(
                 ),
                 class_="sb-section",
             ),
-
+            ui.div(
+                ui.div("Bar Chart Statistic", class_="sb-label"),
+                ui.input_select(
+                    "summary_stat", label=None,
+                    choices=SUMMARY_CHOICES, selected="sum",
+                ),
+                class_="sb-section",
+            ),
             ui.input_action_button("reset_button", "↺  Reset All Filters"),
 
             width=236,

--- a/src/app.py
+++ b/src/app.py
@@ -558,7 +558,7 @@ app_ui = ui.page_fillable(
                 ui.input_selectize(
                     "countries", label=None,
                     choices={"_all_": "— All Countries —"} | {c: c for c in COUNTRIES},
-                    selected=COUNTRIES, multiple=True,
+                    selected=["Brazil", "Bangladesh", "South Africa"], multiple=True,
                     options={"placeholder": "Select countries…", "plugins": ["remove_button"], "closeAfterSelect": False},
                 ),
                 ui.div(
@@ -669,7 +669,7 @@ app_ui = ui.page_fillable(
 
             # Footer
             ui.div(
-                ui.span("Disaster Dash v2  ·  "),
+                ui.span("Disaster Dash v3  ·  "),
                 ui.span("Ojasv Issar, Joel Nicholas Peterson, Claire Saunders  ·  "),
                 ui.a("GitHub", href="https://github.com/UBC-MDS/DSCI-532_2026_18_disasterdash", target="_blank"),
                 ui.span(f"  ·  Data through {LAST_UPDATED}"),
@@ -713,7 +713,7 @@ def server(input, output, session):
     @reactive.effect
     @reactive.event(input.reset_button)
     def _reset():
-        ui.update_selectize("countries",     selected=COUNTRIES,      session=session)
+        ui.update_selectize("countries",     selected=["Brazil", "Bangladesh", "South Africa"],      session=session)
         ui.update_selectize("disaster_type", selected=DISASTER_TYPES, session=session)
         ui.update_select("summary_stat",     selected="sum",          session=session)
         ui.update_select("map_metric",       selected="disasters",    session=session)

--- a/src/app.py
+++ b/src/app.py
@@ -290,7 +290,7 @@ html, body, .bslib-page-fill {{
 #reset_button {{
     display: block;
     width: calc(100% - 28px);
-    margin: 18px 14px 14px !important;
+    margin: 10px 14px 14px !important;
     background: #fff5f5 !important;
     color: {RED} !important;
     border: 1px solid #fee2e2 !important;
@@ -664,7 +664,7 @@ app_ui = ui.page_fillable(
 
             # Footer
             ui.div(
-                ui.span("Disaster Dash (v3  ·  "),
+                ui.span("Disaster Dash (v3)  ·  "),
                 ui.span("Ojasv Issar, Joel Nicholas Peterson, Claire Saunders  ·  "),
                 ui.a("GitHub", href="https://github.com/UBC-MDS/DSCI-532_2026_18_disasterdash", target="_blank"),
                 ui.span(f"  ·  Data through {LAST_UPDATED}"),
@@ -735,7 +735,7 @@ def server(input, output, session):
             lbl("Countries:"),  pill(fmt(countries, COUNTRIES, "All Countries")), sep(),
             lbl("Disasters:"),  pill(fmt(disasters, DISASTER_TYPES, "All Types")), sep(),
             lbl("Dates:"),      pill(f"{start} → {end}"), sep(),
-            lbl("Statistic:"),  pill(SUMMARY_CHOICES[input.summary_stat()]), sep(),
+            lbl("Bar Chart Stat:"),  pill(SUMMARY_CHOICES[input.summary_stat()]), sep(),
             lbl("Map Metric:"), pill(MAP_METRICS[input.map_metric()]),
         )
 


### PR DESCRIPTION
### Improve default filters and sidebar configuration

Closes #69 
References #58 

This PR improves the default state of the dashboard and refines sidebar filter behavior to provide a clearer initial analytical view. KPI cards show the old version in this PR as this PR ONLY deals with filter behaviour and defaults.

**Please note** I shifted from updating the default to JUST Brazil to show the the top three regions. I found with just Brazil it appeared a bit stark, and there was no obvious visual comparison on the map. As a policy maker you might wonder why you are just looking at Brazil, it provides no comparison or context globally, but looking at the top three you see if there is a regional pattern. I thought this retained our goal of simplified narrative but improved its execution. Happy to hear your thoughts on this though! 

**Key updates**

* Updated default countries to **Brazil, Bangladesh, and South Africa** to highlight regions with the highest disaster counts and economic impacts. 
* Reordered sidebar filters to follow a more intuitive analytical flow:
  **Country → Disaster Type → Date Range → Map Metric → Bar Chart Statistic**.
* Updated the default **map metric** to **Economic Loss (USD)** to better support the dashboard’s focus on disaster impact and aid coverage.
* Clarified filter labels by renaming **“Statistic” → “Bar Chart Statistic.”**
* Updated the **active filter strip** to reflect the new terminology.
* Ensured the **Reset All Filters** button restores all inputs to the updated defaults.

These changes improve the dashboard’s initial storytelling and make the filtering interface more intuitive for users. 