### PR TITLE
removed orange in header

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -186,11 +186,8 @@ html, body, .bslib-page-fill {{
 }}
 #page-header .logo {{
     width: 42px; height: 42px;
-    background: linear-gradient(135deg, {AMBER} 0%, #f97316 100%);
-    border-radius: 10px;
     display: flex; align-items: center; justify-content: center;
-    font-size: 1.3rem;
-    box-shadow: 0 4px 14px rgba(245,158,11,0.35);
+    font-size: 1.8rem;
     flex-shrink: 0;
 }}
 #page-header h1 {{


### PR DESCRIPTION
Hi Team,

Just a small change, we discussed removing the orange in the logo in the header so I did that in this PR, it's just the globe against the navy header now instead of on an orange square.  :) 

Cheers