### PR TITLE
Scaled vert bar charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@
 - Added explanatory subtitles and formulas to KPI cards to clarify metric calculations.
 
 
-
 ## Changed:
 
 - Replaced **Aid Coverage %** and **Funding Gap** with:
    **Total Unfunded Disaster Losses**
    **Disaster Burden (% of GDP)**.
+- Flipped all bar charts vertically aligned with some scaling
+- Changed the bar chart color themes to the more moderate 'teal' 
 
 
 ## Fixed:

--- a/src/app.py
+++ b/src/app.py
@@ -1191,7 +1191,7 @@ def server(input, output, session):
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
                 showgrid=False, zeroline=False, showline=True, linecolor=BORDER,
                 automargin=True,
-                range=[-0.5, len(grp) - 0.5],  # prevents clipping regardless of value range
+                autorange=True,  # let Plotly calculate range naturally
             ),
             margin=dict(l=60, r=20, t=10, b=80),
             height=274,

--- a/src/app.py
+++ b/src/app.py
@@ -1064,7 +1064,7 @@ def server(input, output, session):
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n       = len(grp)
-        palette = pc.sample_colorscale("plasma", [i / max(n - 1, 1) for i in range(n)])
+        palette = pc.sample_colorscale("mako", [i / max(n - 1, 1) for i in range(n)])
 
         y_max   = grp[column].max()
         y_range = [0, y_max * 1.25]
@@ -1164,7 +1164,7 @@ def server(input, output, session):
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n = len(grp)
-        palette = pc.sample_colorscale("plasma", [i / max(n - 1, 1) for i in range(n)])
+        palette = pc.sample_colorscale("mako", [i / max(n - 1, 1) for i in range(n)])
 
         y_max   = grp[column].max()
         y_range = [0, y_max * 1.25]

--- a/src/app.py
+++ b/src/app.py
@@ -1064,7 +1064,7 @@ def server(input, output, session):
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n       = len(grp)
-        palette = pc.sample_colorscale("magma", [i / max(n - 1, 1) for i in range(n)])
+        palette = pc.sample_colorscale("plasma", [i / max(n - 1, 1) for i in range(n)])
 
         y_max   = grp[column].max()
         y_range = [0, y_max * 1.25]
@@ -1073,7 +1073,6 @@ def server(input, output, session):
             x=grp["disaster_type"],
             y=grp[column],
             orientation="v",
-            width=0.5,  # fixed bar width — no horizontal scaling
             marker=dict(color=palette, line=dict(width=0)),
             customdata=grp[["fmt"]],
             hovertemplate="<b>%{x}</b><br>" + f"{y_label}: %{{customdata[0]}}<extra></extra>",
@@ -1095,7 +1094,6 @@ def server(input, output, session):
             ),
             xaxis=dict(
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
-                tickangle=-35,  # angled labels like right chart
                 showgrid=False, zeroline=False, showline=True, linecolor=BORDER,
                 automargin=True,
             ),
@@ -1165,7 +1163,7 @@ def server(input, output, session):
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n = len(grp)
-        palette = pc.sample_colorscale("magma", [i / max(n - 1, 1) for i in range(n)])
+        palette = pc.sample_colorscale("plasma", [i / max(n - 1, 1) for i in range(n)])
 
         y_max   = grp[column].max()
         y_range = [0, y_max * 1.25]

--- a/src/app.py
+++ b/src/app.py
@@ -1163,7 +1163,7 @@ def server(input, output, session):
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n = len(grp)
-        palette = pc.sample_colorscale("plasma", [i / max(n - 1, 1) for i in range(n)])
+        palette = pc.sample_colorscale("magma", [i / max(n - 1, 1) for i in range(n)])
 
         y_max   = grp[column].max()
         y_range = [0, y_max * 1.25]
@@ -1172,7 +1172,7 @@ def server(input, output, session):
             x=grp["disaster_type"],
             y=grp[column],
             orientation="v",
-            marker=dict(color=palette, line=dict(width=0.5)),
+            marker=dict(color=palette, line=dict(width=0)),
             customdata=grp[["fmt"]],
             hovertemplate="<b>%{x}</b><br>" + f"{y_label}: %{{customdata[0]}}<extra></extra>",
             text=grp["fmt"],
@@ -1189,7 +1189,8 @@ def server(input, output, session):
             xaxis=dict(
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
                 showgrid=False, zeroline=False, showline=True, linecolor=BORDER,
-                automargin=True, tickangle=-35,
+                automargin=True,
+                range=[-0.5, len(grp) - 0.5],  # prevents clipping regardless of value range
             ),
             margin=dict(l=60, r=20, t=10, b=80),
             height=274,

--- a/src/app.py
+++ b/src/app.py
@@ -1064,7 +1064,7 @@ def server(input, output, session):
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n       = len(grp)
-        palette = pc.sample_colorscale("mako", [i / max(n - 1, 1) for i in range(n)])
+        palette = pc.sample_colorscale("teal", [i / max(n - 1, 1) for i in range(n)])
 
         y_max   = grp[column].max()
         y_range = [0, y_max * 1.25]
@@ -1164,7 +1164,7 @@ def server(input, output, session):
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n = len(grp)
-        palette = pc.sample_colorscale("mako", [i / max(n - 1, 1) for i in range(n)])
+        palette = pc.sample_colorscale("teal", [i / max(n - 1, 1) for i in range(n)])
 
         y_max   = grp[column].max()
         y_range = [0, y_max * 1.25]

--- a/src/app.py
+++ b/src/app.py
@@ -1096,7 +1096,7 @@ def server(input, output, session):
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
                 showgrid=False, zeroline=False, showline=True, linecolor=BORDER,
                 automargin=True,
-                range=[-0.5, len(grp) - 0.5],  # prevents clipping regardless of value range
+                autorange=True,  # let Plotly calculate range naturally
             ),
             margin=dict(l=60, r=20, t=22, b=80),
             height=274,

--- a/src/app.py
+++ b/src/app.py
@@ -1096,6 +1096,7 @@ def server(input, output, session):
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
                 showgrid=False, zeroline=False, showline=True, linecolor=BORDER,
                 automargin=True,
+                range=[-0.5, len(grp) - 0.5],  # prevents clipping regardless of value range
             ),
             margin=dict(l=60, r=20, t=22, b=80),
             height=274,
@@ -1163,7 +1164,7 @@ def server(input, output, session):
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n = len(grp)
-        palette = pc.sample_colorscale("magma", [i / max(n - 1, 1) for i in range(n)])
+        palette = pc.sample_colorscale("plasma", [i / max(n - 1, 1) for i in range(n)])
 
         y_max   = grp[column].max()
         y_range = [0, y_max * 1.25]

--- a/src/app.py
+++ b/src/app.py
@@ -1060,13 +1060,12 @@ def server(input, output, session):
         grp = (
             data.groupby("disaster_type")[column]
             .agg(stat).reset_index()
-            .sort_values(column, ascending=False)  # descending for vertical
+            .sort_values(column, ascending=False)
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n       = len(grp)
         palette = pc.sample_colorscale("magma", [i / max(n - 1, 1) for i in range(n)])
 
-        # Dynamic y-axis range with 20% headroom for labels
         y_max   = grp[column].max()
         y_range = [0, y_max * 1.25]
 
@@ -1074,6 +1073,7 @@ def server(input, output, session):
             x=grp["disaster_type"],
             y=grp[column],
             orientation="v",
+            width=0.5,  # fixed bar width — no horizontal scaling
             marker=dict(color=palette, line=dict(width=0)),
             customdata=grp[["fmt"]],
             hovertemplate="<b>%{x}</b><br>" + f"{y_label}: %{{customdata[0]}}<extra></extra>",
@@ -1091,10 +1091,11 @@ def server(input, output, session):
                 title=dict(text=y_label, font=dict(size=9, color=T_SEC, family="Instrument Sans")),
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
                 gridcolor=BORDER, showgrid=True, zeroline=False, showline=False,
-                range=y_range,  # dynamic range
+                range=y_range,
             ),
             xaxis=dict(
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
+                tickangle=-35,  # angled labels like right chart
                 showgrid=False, zeroline=False, showline=True, linecolor=BORDER,
                 automargin=True,
             ),
@@ -1164,7 +1165,7 @@ def server(input, output, session):
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n = len(grp)
-        palette = pc.sample_colorscale("cividis", [i / max(n - 1, 1) for i in range(n)])
+        palette = pc.sample_colorscale("magma", [i / max(n - 1, 1) for i in range(n)])
 
         y_max   = grp[column].max()
         y_range = [0, y_max * 1.25]
@@ -1173,7 +1174,7 @@ def server(input, output, session):
             x=grp["disaster_type"],
             y=grp[column],
             orientation="v",
-            marker=dict(color=palette, line=dict(width=0)),
+            marker=dict(color=palette, line=dict(width=0.5)),
             customdata=grp[["fmt"]],
             hovertemplate="<b>%{x}</b><br>" + f"{y_label}: %{{customdata[0]}}<extra></extra>",
             text=grp["fmt"],
@@ -1190,7 +1191,7 @@ def server(input, output, session):
             xaxis=dict(
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
                 showgrid=False, zeroline=False, showline=True, linecolor=BORDER,
-                automargin=True,
+                automargin=True, tickangle=-35,
             ),
             margin=dict(l=60, r=20, t=10, b=80),
             height=274,

--- a/src/app.py
+++ b/src/app.py
@@ -1060,19 +1060,23 @@ def server(input, output, session):
         grp = (
             data.groupby("disaster_type")[column]
             .agg(stat).reset_index()
-            .sort_values(column, ascending=True)
+            .sort_values(column, ascending=False)  # descending for vertical
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n       = len(grp)
         palette = pc.sample_colorscale("magma", [i / max(n - 1, 1) for i in range(n)])
 
+        # Dynamic y-axis range with 20% headroom for labels
+        y_max   = grp[column].max()
+        y_range = [0, y_max * 1.25]
+
         fig = go.Figure(go.Bar(
-            y=grp["disaster_type"],
-            x=grp[column],
-            orientation="h",
+            x=grp["disaster_type"],
+            y=grp[column],
+            orientation="v",
             marker=dict(color=palette, line=dict(width=0)),
             customdata=grp[["fmt"]],
-            hovertemplate="<b>%{y}</b><br>" + f"{y_label}: %{{customdata[0]}}<extra></extra>",
+            hovertemplate="<b>%{x}</b><br>" + f"{y_label}: %{{customdata[0]}}<extra></extra>",
             text=grp["fmt"],
             textposition="outside",
             textfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
@@ -1083,17 +1087,18 @@ def server(input, output, session):
                 x=1, y=1.05, xanchor="right", yanchor="bottom",
                 showarrow=False, font=dict(size=9, color=T_SEC, family="Instrument Sans"),
             )],
-            xaxis=dict(
+            yaxis=dict(
                 title=dict(text=y_label, font=dict(size=9, color=T_SEC, family="Instrument Sans")),
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
                 gridcolor=BORDER, showgrid=True, zeroline=False, showline=False,
+                range=y_range,  # dynamic range
             ),
-            yaxis=dict(
+            xaxis=dict(
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
                 showgrid=False, zeroline=False, showline=True, linecolor=BORDER,
                 automargin=True,
             ),
-            margin=dict(l=10, r=70, t=22, b=42),
+            margin=dict(l=60, r=20, t=22, b=80),
             height=274,
             paper_bgcolor="rgba(0,0,0,0)",
             plot_bgcolor="rgba(0,0,0,0)",
@@ -1155,35 +1160,39 @@ def server(input, output, session):
         grp = (
             data.groupby("disaster_type")[column]
             .sum().reset_index()
-            .sort_values(column, ascending=True)
+            .sort_values(column, ascending=False)
         )
         grp["fmt"] = grp[column].apply(fmt_currency)
         n = len(grp)
         palette = pc.sample_colorscale("cividis", [i / max(n - 1, 1) for i in range(n)])
 
+        y_max   = grp[column].max()
+        y_range = [0, y_max * 1.25]
+
         fig = go.Figure(go.Bar(
-            y=grp["disaster_type"],
-            x=grp[column],
-            orientation="h",
+            x=grp["disaster_type"],
+            y=grp[column],
+            orientation="v",
             marker=dict(color=palette, line=dict(width=0)),
             customdata=grp[["fmt"]],
-            hovertemplate="<b>%{y}</b><br>" + f"{y_label}: %{{customdata[0]}}<extra></extra>",
+            hovertemplate="<b>%{x}</b><br>" + f"{y_label}: %{{customdata[0]}}<extra></extra>",
             text=grp["fmt"],
             textposition="outside",
             textfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
         ))
         fig.update_layout(
-            xaxis=dict(
+            yaxis=dict(
                 title=dict(text=y_label, font=dict(size=9, color=T_SEC, family="Instrument Sans")),
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
                 gridcolor=BORDER, showgrid=True, zeroline=False, showline=False,
+                range=y_range,
             ),
-            yaxis=dict(
+            xaxis=dict(
                 tickfont=dict(size=8, color=T_SEC, family="Instrument Sans"),
                 showgrid=False, zeroline=False, showline=True, linecolor=BORDER,
                 automargin=True,
             ),
-            margin=dict(l=10, r=70, t=10, b=42),
+            margin=dict(l=60, r=20, t=10, b=80),
             height=274,
             paper_bgcolor="rgba(0,0,0,0)",
             plot_bgcolor="rgba(0,0,0,0)",


### PR DESCRIPTION
This PR addresses Issue #62: 

- flipped bar charts vertically with some scaling
-  ensured uniform formatting among the 4 bar charts
- changed the bar chart theme to 'teal' for a softer visual

