### PR TITLE
Fix API : Switch from Groq to Anthropic 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ conda activate disaster-dash
 
 4. Configure environment variables
 
-The **AI Explorer** tab uses the Groq API to power natural-language queries.  
-To run the app locally, you must provide a Groq API key.
+The **AI Explorer** tab uses the **Anthropic API** to power natural-language queries.
 
-- Create a free API key at:  
-  https://console.groq.com/keys
+To run the AI Explorer locally, you must provide an Anthropic API key.
+
+
+- Create an API key at:  
+  https://console.anthropic.com/
 
 - In the project root, create a `.env` file:
 
@@ -55,7 +57,7 @@ touch .env
 - Add your API key to the file:
 
 ```bash
-GROQ_API_KEY=your_key_here
+ANTHROPIC_API_KEY=your_key_here
 ```
 
 The application automatically loads this key using `python-dotenv`.

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - duckdb
   - pip:
       - anywidget
-      - groq
       - python-dotenv
       - querychat
+      - chatlas
+      - anthropic

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv>=1.0
 querychat==0.5.1
 shiny==1.5.1
 shinywidgets==0.7.1
+ibis-framework[duckdb]==12.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 anywidget==0.9.21
-groq>=0.9.0
+anthropic==0.84.0
 pandas==3.0.1
 plotly==6.5.2
 python-dotenv>=1.0

--- a/src/app.py
+++ b/src/app.py
@@ -104,20 +104,16 @@ QUESTION_MAP = {
 LAST_UPDATED = datetime.today().strftime("%B %d, %Y")
 
 # ── QueryChat Config ───────────────────────────────────────────────────────────
-# Uses Groq API with meta-llama/llama-4-maverick-17b-128e-instruct
-# (Llama 4 Maverick — fast, free tier, reliable tool/function calling).
-# Prerequisites:
-#   Add to your .env file:  GROQ_API_KEY=your_key_here
+# Uses Anthropic Claude (Haiku) for natural language dataframe queries
+# Requires ANTHROPIC_API_KEY set locally or in Posit Connect secrets
 
 import chatlas, os as _os, sys as _sys
 
-_groq_key = _os.getenv("GROQ_API_KEY")
-if not _groq_key:
+_anthropic_key = _os.getenv("ANTHROPIC_API_KEY")
+if not _anthropic_key:
     print(
-        "\n❌  GROQ_API_KEY is not set.\n"
-        "   1. Get a free key at https://console.groq.com/keys\n"
-        "   2. Add to .env:  GROQ_API_KEY=your_key_here\n"
-        "   3. Re-run:       shiny run src/app.py\n",
+        "\n❌  ANTHROPIC_API_KEY is not set.\n"
+        "   Add it to your .env or Posit Connect secrets.\n",
         file=_sys.stderr,
     )
     _sys.exit(1)
@@ -125,7 +121,7 @@ if not _groq_key:
 qc = QueryChat(
     df,
     "global_disaster_response_2018_2024",
-    client=chatlas.ChatGroq(model="meta-llama/llama-4-maverick-17b-128e-instruct", api_key=_groq_key),
+    client=chatlas.ChatAnthropic(model="claude-3-haiku-20240307", api_key=_anthropic_key),
     greeting="""Hi! I'm your **Disaster Dash AI assistant** 🌍
 
 Ask me natural language questions to filter the disaster dataset. Try:


### PR DESCRIPTION
Hi Team,

This is a bug fix and References #97, feedback from Chikire who noticed that our chatbot was throwing an error. Our GROQ API stopped working as the model was decommissioned (it was running previously and has since started throwing errors). I have updated our API setup from Groq to Anthropic. This fixes our query chat bot so it is functional again. I didn't change anything else about our code or chat bot set up, just the API. 

Summary of Changes:
- Change api key and api querychat code from groq to anthropic
- Update ReadME document to reflect anthropic key set up instead of groq
- Update environment.yml to include anthropic instead of groq
- Update requirements.txt to include anthropic instead of groq so the posit connect cloud runs

I tested both locally and on posit and the bot is up and running again. 

