### PR TITLE
modularize helper functions and add pytests

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,8 @@
 Disaster Dash (v3) — AI Explorer Tab Added
 Global Disaster Impact & Humanitarian Aid (2018–2024)
 """
-
+from src.fmt_currency import fmt_currency
+from src.fmt_num import fmt_num 
 from shiny import App, ui, render, reactive
 from shinywidgets import output_widget, render_widget
 from pathlib import Path
@@ -60,19 +61,19 @@ GDP = {
     "South Africa": 401144998373.585,
 }
 # ── Helpers ────────────────────────────────────────────────────────────────────
-def fmt_currency(v):
-    s = "-" if v < 0 else ""
-    v = abs(v)
-    if v >= 1e12:  return f"{s}${v/1e12:.2f}T"
-    if v >= 1e9:   return f"{s}${v/1e9:.1f}B"
-    if v >= 1e6:   return f"{s}${v/1e6:.1f}M"
-    if v >= 1e3:   return f"{s}${v/1e3:.1f}K"
-    return f"{s}${v:.0f}"
+# def fmt_currency(v):
+#     s = "-" if v < 0 else ""
+#     v = abs(v)
+#     if v >= 1e12:  return f"{s}${v/1e12:.2f}T"
+#     if v >= 1e9:   return f"{s}${v/1e9:.1f}B"
+#     if v >= 1e6:   return f"{s}${v/1e6:.1f}M"
+#     if v >= 1e3:   return f"{s}${v/1e3:.1f}K"
+#     return f"{s}${v:.0f}"
 
-def fmt_num(v):
-    if v >= 1e6:  return f"{v/1e6:.1f}M"
-    if v >= 1e3:  return f"{v/1e3:.1f}K"
-    return f"{v:,.0f}"
+# def fmt_num(v):
+#     if v >= 1e6:  return f"{v/1e6:.1f}M"
+#     if v >= 1e3:  return f"{v/1e3:.1f}K"
+#     return f"{v:,.0f}"
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 COUNTRIES      = sorted(ISO3.keys())

--- a/src/fmt_currency.py
+++ b/src/fmt_currency.py
@@ -1,0 +1,25 @@
+def fmt_currency(v: float) -> str:
+    """Return a compact, human-readable currency string.
+ 
+    Examples
+    --------
+    >>> fmt_currency(1_500_000_000_000)
+    '$1.50T'
+    >>> fmt_currency(2_300_000_000)
+    '$2.3B'
+    >>> fmt_currency(-450_000)
+    '-$450.0K'
+    >>> fmt_currency(0)
+    '$0'
+    """
+    sign = "-" if v < 0 else ""
+    v = abs(v)
+    if v >= 1e12:
+        return f"{sign}${v / 1e12:.2f}T"
+    if v >= 1e9:
+        return f"{sign}${v / 1e9:.1f}B"
+    if v >= 1e6:
+        return f"{sign}${v / 1e6:.1f}M"
+    if v >= 1e3:
+        return f"{sign}${v / 1e3:.1f}K"
+    return f"{sign}${v:.0f}"

--- a/src/fmt_num.py
+++ b/src/fmt_num.py
@@ -1,0 +1,17 @@
+def fmt_num(v: float) -> str:
+    """Return a compact, human-readable number string (no currency symbol).
+ 
+    Examples
+    --------
+    >>> fmt_num(2_500_000)
+    '2.5M'
+    >>> fmt_num(18_000)
+    '18.0K'
+    >>> fmt_num(42)
+    '42'
+    """
+    if v >= 1e6:
+        return f"{v / 1e6:.1f}M"
+    if v >= 1e3:
+        return f"{v / 1e3:.1f}K"
+    return f"{v:,.0f}"

--- a/tests/test_fmt_currency.py
+++ b/tests/test_fmt_currency.py
@@ -1,0 +1,22 @@
+"""
+pytest tests for fmt_currency helper function 
+"""
+import sys                   
+sys.path.insert(0, ".")  # look in root
+
+from src.fmt_currency import fmt_currency
+
+def test_billions():
+    assert fmt_currency(2_300_000_000) == "$2.3B"
+
+def test_millions():
+    assert fmt_currency(450_000_000) == "$450.0M"
+
+def test_thousands():
+    assert fmt_currency(7_500) == "$7.5K"
+
+def test_zero():
+    assert fmt_currency(0) == "$0"
+
+def test_negative():
+    assert fmt_currency(-2_300_000_000) == "-$2.3B"

--- a/tests/test_fmt_num.py
+++ b/tests/test_fmt_num.py
@@ -1,0 +1,19 @@
+"""
+pytest tests for fmt_num helper function
+"""
+import sys
+sys.path.insert(0, ".")   # look in root
+
+from src.fmt_num import fmt_num
+
+def test_millions():
+    assert fmt_num(2_500_000) == "2.5M"
+
+def test_thousands():
+    assert fmt_num(18_000) == "18.0K"
+
+def test_thousands():
+    assert fmt_num(18_000) == "18.0K"
+ 
+def test_sub_thousand():
+    assert fmt_num(42) == "42"


### PR DESCRIPTION
This PR:

-  refactors app.py  creating separate modules for 2 helper functions: fmt_num, fmt_currency
- creates test files for the helper functions in a /tests directory with pytest
- multiple tests per function with all passing
- added __init__.py file to source to be treated as a module
- added pytest.ini file 