### PR TITLE
Improvement: Add meaningful global baselines to KPI's (addresses instructor feedback)

### DIFF
--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -92,15 +92,19 @@ flowchart TD
 
 ### KPI Calculations
 
-### `kpi_grid` — Total Unfunded Disaster Losses
-- **Formula:** `sum(economic_loss_usd) - sum(aid_amount_usd)`
-- **Meaning:** Represents the total disaster-related economic loss not covered by humanitarian aid across the filtered selection.
+### `kpi_grid` — Average Unfunded Loss per Disaster
+- **Formula:** `mean(loss − aid)` where `loss = economic_loss_usd` and `aid = aid_amount_usd`
+- **Meaning:** Represents the typical funding gap per disaster event within the filtered selection.
+- **Baseline comparison:** The filtered value is compared to the **global historical average disaster funding gap**, computed as the mean disaster funding gap across all disaster events in the dataset (2018–2024).
 
 ### `kpi_grid` — Disaster Burden (% of GDP)
 - **Formula:** `median((economic_loss_usd - aid_amount_usd) / GDP × 100)` computed at the country level.
 - **Meaning:** Represents the typical disaster funding gap relative to a country's economic size, allowing comparison between large and small economies.
+- **Baseline comparison:** The filtered value is compared to the **global median disaster burden**, computed as the median country-level disaster burden across all countries in the dataset (2018–2024).
 
-Both KPIs always use **sum aggregation** for loss and aid regardless of the `summary_stat` selection used in the bar charts.
+These KPI calculations are independent of the `summary_stat` selection used in the bar charts. The first KPI computes the **average disaster funding gap**, while the second KPI computes the **median disaster burden relative to GDP**.
+
+The dashboard displays ▲ or ▼ indicators to show whether the selected disasters exhibit **larger or smaller funding gaps relative to global historical baselines**.
 
 ### Map Aggregation (inline)
 - **Depends on:** `filtered_df`, `map_metric`

--- a/src/app.py
+++ b/src/app.py
@@ -103,6 +103,34 @@ QUESTION_MAP = {
 }
 LAST_UPDATED = datetime.today().strftime("%B %d, %Y")
 
+# ── Global KPI Baselines ─────────────────────────────────────────────
+
+# funding gap per disaster event
+df["gap"] = df["economic_loss_usd"] - df["aid_amount_usd"]
+
+# baseline for KPI 1: average disaster funding gap globally
+GLOBAL_GAP_PER_EVENT = df["gap"].mean()
+
+# baseline for KPI 2: disaster burden relative to GDP
+country_baseline = (
+    df.groupby("country")
+      .agg(
+          loss=("economic_loss_usd", "sum"),
+          aid=("aid_amount_usd", "sum")
+      )
+      .reset_index()
+)
+
+country_baseline["gap"] = country_baseline["loss"] - country_baseline["aid"]
+country_baseline["gdp"] = country_baseline["country"].map(GDP)
+
+country_baseline["gap_pct_gdp"] = (
+    country_baseline["gap"] / country_baseline["gdp"]
+) * 100
+
+# global median disaster burden
+GLOBAL_GAP_MEDIAN = country_baseline["gap_pct_gdp"].median()
+
 # ── QueryChat Config ───────────────────────────────────────────────────────────
 # Uses Anthropic Claude (Haiku) for natural language dataframe queries
 # Requires ANTHROPIC_API_KEY set locally or in Posit Connect secrets
@@ -902,12 +930,23 @@ def server(input, output, session):
         if data.empty:
             gap_dollar_val = "-"
             gap_pct_val = "-"
+            gap_subtitle = ""
+            gap_pct_subtitle = ""
         else:
-            # Total Funding Gap
-            total_loss    = data["economic_loss_usd"].sum()
-            total_aid     = data["aid_amount_usd"].sum()
-            total_gap     = total_loss - total_aid
-            gap_dollar_val = fmt_currency(total_gap)
+            # ── KPI 1: Average Funding Gap per Disaster ───────────────────
+
+            data["gap"] = data["economic_loss_usd"] - data["aid_amount_usd"]
+            gap_per_event = data["gap"].mean()
+            gap_dollar_val = fmt_currency(gap_per_event)
+            gap_delta = (
+                (gap_per_event - GLOBAL_GAP_PER_EVENT)
+                / GLOBAL_GAP_PER_EVENT
+            ) * 100
+            gap_arrow = ""
+            gap_arrow = "▲" if gap_delta > 0 else "▼"
+            gap_subtitle = (
+                f"{gap_arrow} {abs(gap_delta):.1f}% vs global average"
+            )
             # GDP Normalized Median Gap (%)
             agg = (
                 data.groupby("country").agg(
@@ -924,6 +963,11 @@ def server(input, output, session):
                 agg["gap_pct_gdp"] = (agg["gap"]/agg["gdp"])*100
                 median_gap_pct = agg["gap_pct_gdp"].median()
                 gap_pct_val = f"{median_gap_pct:.2f}%"
+                pct_delta = median_gap_pct - GLOBAL_GAP_MEDIAN
+                pct_arrow = "▲" if pct_delta > 0 else "▼"
+                gap_pct_subtitle = (
+                    f"{pct_arrow} {abs(pct_delta):.2f}% vs global median"
+                )
 
         def kpi_box(cls, value, title, subtitle=None, formula=None):
             return ui.div(
@@ -937,14 +981,14 @@ def server(input, output, session):
         return ui.div(
             kpi_box("kpi-gap",
                      gap_dollar_val, 
-                     "Total Unfunded Disaster Losses", 
-                     "Disaster losses not covered by aid",
-                     "Loss - Aid", 
+                     "Average Unfunded Loss per Disaster", 
+                     gap_subtitle,
+                     "mean(Loss - Aid)", 
                      ),
             kpi_box("kpi-coverage", 
                     gap_pct_val, 
                     "Disaster Burden (% of GDP)",
-                    "Typical funding gap relative to GDP", 
+                    gap_pct_subtitle,
                     "Median((Loss − Aid) ÷ GDP)", 
                     ),
             class_="kpi-grid",

--- a/src/app.py
+++ b/src/app.py
@@ -935,19 +935,21 @@ def server(input, output, session):
         else:
             # ── KPI 1: Average Funding Gap per Disaster ───────────────────
 
-            data["gap"] = data["economic_loss_usd"] - data["aid_amount_usd"]
-            gap_per_event = data["gap"].mean()
+            gap_per_event = (data["economic_loss_usd"] - data["aid_amount_usd"]).mean()
             gap_dollar_val = fmt_currency(gap_per_event)
-            gap_delta = (
-                (gap_per_event - GLOBAL_GAP_PER_EVENT)
-                / GLOBAL_GAP_PER_EVENT
-            ) * 100
-            gap_arrow = ""
+            if GLOBAL_GAP_PER_EVENT != 0:
+                gap_delta = (
+                    (gap_per_event - GLOBAL_GAP_PER_EVENT)
+                    / GLOBAL_GAP_PER_EVENT
+                ) * 100
+            else:
+                gap_delta = 0
             gap_arrow = "▲" if gap_delta > 0 else "▼"
             gap_color = RED if gap_delta > 0 else GREEN
+            direction = "higher" if gap_delta > 0 else "lower"
             gap_subtitle = ui.HTML(
-                f"<span style='color:{gap_color}'>{gap_arrow} {abs(gap_delta):.1f}%</span> vs global average"
-                )
+                f"<span style='color:{gap_color}'>{gap_arrow} {abs(gap_delta):.1f}% {direction}</span> than global average"
+            )
             # GDP Normalized Median Gap (%)
             agg = (
                 data.groupby("country").agg(
@@ -967,9 +969,10 @@ def server(input, output, session):
                 pct_delta = median_gap_pct - GLOBAL_GAP_MEDIAN
                 pct_arrow = "▲" if pct_delta > 0 else "▼"
                 pct_color = RED if pct_delta > 0 else GREEN
+                direction = "higher" if pct_delta > 0 else "lower"
                 gap_pct_subtitle = ui.HTML(
-                    f"<span style='color:{pct_color}'>{pct_arrow} {abs(pct_delta):.2f}%</span> vs global median"
-                    )
+                    f"<span style='color:{pct_color}'>{pct_arrow} {abs(pct_delta):.2f}% {direction}</span> than global median"
+                )
 
 
         def kpi_box(cls, value, title, subtitle=None, formula=None):

--- a/src/app.py
+++ b/src/app.py
@@ -944,9 +944,10 @@ def server(input, output, session):
             ) * 100
             gap_arrow = ""
             gap_arrow = "▲" if gap_delta > 0 else "▼"
-            gap_subtitle = (
-                f"{gap_arrow} {abs(gap_delta):.1f}% vs global average"
-            )
+            gap_color = RED if gap_delta > 0 else GREEN
+            gap_subtitle = ui.HTML(
+                f"<span style='color:{gap_color}'>{gap_arrow} {abs(gap_delta):.1f}%</span> vs global average"
+                )
             # GDP Normalized Median Gap (%)
             agg = (
                 data.groupby("country").agg(
@@ -965,9 +966,11 @@ def server(input, output, session):
                 gap_pct_val = f"{median_gap_pct:.2f}%"
                 pct_delta = median_gap_pct - GLOBAL_GAP_MEDIAN
                 pct_arrow = "▲" if pct_delta > 0 else "▼"
-                gap_pct_subtitle = (
-                    f"{pct_arrow} {abs(pct_delta):.2f}% vs global median"
-                )
+                pct_color = RED if pct_delta > 0 else GREEN
+                gap_pct_subtitle = ui.HTML(
+                    f"<span style='color:{pct_color}'>{pct_arrow} {abs(pct_delta):.2f}%</span> vs global median"
+                    )
+
 
         def kpi_box(cls, value, title, subtitle=None, formula=None):
             return ui.div(


### PR DESCRIPTION
‼️ **PLEASE NOTE:** this PR is built on top of the DuckDB reactivity branch, so I’ve opened it against that branch instead of dev so the diff is clean and doesn't show both branch updates. Once the DuckDB PR is merged into dev, we can update this PR to merge into dev as well 

This PR updates the dashboard KPIs to include clear comparative baselines, addressing Ilya’s feedback that the previous KPIs lacked meaningful context for interpretation. References #84. 

### Motivation

Previously, the KPI cards displayed raw values without a clear benchmark, which made it difficult for users to determine whether the selected disasters represented **better or worse outcomes relative to global disaster response patterns**.

Following Ilya’s feedback, this update introduces **global historical baselines** so the KPIs provide immediate analytical context for policy users.

### Changes

**1. Updated specification to document:**

* revised KPI 1 calculation
* the new global baseline definitions
* how the KPI comparisons are computed and displayed.

**2. Updated KPI 1 calculation**

The first KPI has been changed from the previous formulation to:

* **Average Unfunded Loss per Disaster**
* `mean(economic_loss_usd − aid_amount_usd)`

This change allows comparison to the global baseline meaningfully with the  **typical funding gap per disaster event**, rather than a total gap that scales with the number of disasters selected and doesn't work well with global baselines.  

**3. Added global baselines to both KPIs**

Both KPI cards now compare the filtered results against **global historical benchmarks**:

* **KPI 1 baseline:**
  `GLOBAL_GAP_PER_EVENT` — global average disaster funding gap per event

* **KPI 2 baseline:**
  `GLOBAL_GAP_MEDIAN` — global median disaster burden relative to GDP

This allows users to immediately see whether the selected disasters represent **higher or lower funding gaps and economic burden compared to typical global disasters**.

**4. Added directional comparison indicators**

Each KPI now displays:

* ▲ / ▼ arrows showing direction vs the baseline
* % difference from the global benchmark
* color cues:

  * **red ▲** → worse than global baseline
  * **green ▼** → better than global baseline

These updates make the KPIs easier to interpret and directly address the instructor feedback about providing **comparative context for policy analysis**.
